### PR TITLE
Allow passing parameters to createDirectory and changeDirectory

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,9 +336,10 @@ class CrowdinApi {
    * Add directory to Crowdin project.
    * @param projectName {String} Should contain the project identifier.
    * @param directory {String} Directory name (with path if nested directory should be created).
+   * @param params {Object} New parameters for the directory.
    */
-  createDirectory(projectName, directory) {
-    return this.postPromise(`project/${projectName}/add-directory`, undefined, {
+  createDirectory(projectName, directory, params) {
+    return this.postPromise(`project/${projectName}/add-directory`, params, {
       name: directory
     });
   }
@@ -350,9 +351,9 @@ class CrowdinApi {
    * @param params {Object} New parameters for the directory.
    */
   changeDirectory(projectName, directory, params) {
-    return this.postPromise(`project/${projectName}/change-directory`, undefined, {
+    return this.postPromise(`project/${projectName}/change-directory`, params, {
       name: directory
-    }, params);
+    });
   }
 
   /**


### PR DESCRIPTION
In order to be able to create a new branch in Crowdin I added a `params` argument to `createDirectory` which gets passed to requests `qs` argument.

I also moved the usage of `params` argument in `changeDirectory` from non-existent 4th argument of `postPromise` to `qs` argument.