### PR TITLE
Define project identifier once in class constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,12 +104,17 @@ function packFiles(files) {
 }
 
 class CrowdinApi {
-  constructor({ baseUrl = 'https://api.crowdin.com', apiKey } = {}) {
+  constructor({ baseUrl = 'https://api.crowdin.com', apiKey, projectName } = {}) {
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
+    this.projectName = projectName;
 
     if (!apiKey) {
       throw new Error('Please specify CrowdIn API key.');
+    }
+
+    if (!projectName) {
+      throw new Error('Please specify CrowdIn project.');
     }
   }
 
@@ -152,84 +157,77 @@ class CrowdinApi {
 
   /**
    * Add new file to Crowdin project
-   * @param projectName {String} Should contain the project identifier
    * @param files {Array} Files array that should be added to Crowdin project.
    *   Array keys should contain file names with path in Crowdin project.
    *   Note! 20 files max are allowed to upload per one time file transfer.
    * @param params {Object} Information about uploaded files.
    */
-  addFile(projectName, files, params) {
-    return this.postPromise(`project/${projectName}/add-file`, undefined, {
+  addFile(files, params) {
+    return this.postPromise(`project/${this.projectName}/add-file`, undefined, {
       ...packFiles(files), ...params
     });
   }
 
   /**
    * Upload latest version of your localization file to Crowdin.
-   * @param projectName {String} Should contain the project identifier
    * @param files {Array} Files array that should be updated.
    *   Note! 20 files max are allowed to upload per one time file transfer.
    * @param params {Object} Information about updated files.
    */
-  updateFile(projectName, files, params) {
-    return this.postPromise(`project/${projectName}/update-file`, undefined, {
+  updateFile(files, params) {
+    return this.postPromise(`project/${this.projectName}/update-file`, undefined, {
       ...packFiles(files), ...params
     });
   }
 
   /**
    * Delete file from Crowdin project. All the translations will be lost without ability to restore them.
-   * @param projectName {String} Should contain the project identifier
    * @param fileName {String} Name of file to delete.
    */
-  deleteFile(projectName, fileName) {
-    return this.postPromise(`project/${projectName}/delete-file`, undefined, {
+  deleteFile(fileName) {
+    return this.postPromise(`project/${this.projectName}/delete-file`, undefined, {
       file: fileName
     });
   }
 
   /**
    * Upload existing translations to your Crowdin project
-   * @param projectName {String} Should contain the project identifier
    * @param files {Array} Translated files array. Array keys should contain file names in Crowdin.
    *   Note! 20 files max are allowed to upload per one time file transfer.
    * @param language {String} Target language. With a single call it's possible to upload translations for several files but only into one of the languages
    * @param params {Object} Information about updated files.
    */
-  updateTranslations(projectName, files, language, params) {
-    return this.postPromise(`project/${projectName}/upload-translation`, undefined, {
+  updateTranslations(files, language, params) {
+    return this.postPromise(`project/${this.projectName}/upload-translation`, undefined, {
       ...packFiles(files), ...params, language
     });
   }
 
   /**
    * Track your Crowdin project translation progress by language.
-   * @param projectName {String} Should contain the project identifier.  */
-  translationStatus(projectName) {
-    return this.postPromise(`project/${projectName}/status`);
+   */
+  translationStatus() {
+    return this.postPromise(`project/${this.projectName}/status`);
   }
 
   /**
    * Get the detailed translation progress for specified language.
-   * @param projectName {String} Should contain the project identifier.
    * @param language {String} Crowdin language codes.  */
-  languageStatus(projectName, language) {
-    return this.postPromise(`project/${projectName}/language-status`, undefined, {
+  languageStatus(language) {
+    return this.postPromise(`project/${this.projectName}/language-status`, undefined, {
       language
     });
   }
 
   /**
    * Get Crowdin Project details.
-   * @param projectName {String} Should contain the project identifier.
    */
-  projectInfo(projectName) {
-    return this.postPromise(`project/${projectName}/info`);
+  projectInfo() {
+    return this.postPromise(`project/${this.projectName}/info`);
   }
 
   /**
    * Get a list of issues reported in the Editor.
-   * @param projectName {String} Should contain the project identifier.
    * @param params {Object} See https://support.crowdin.com/api/issues/
    * @param params.type {String} Defines the issue type.
    * @param params.status {String} Defines the issue resolution status.
@@ -237,13 +235,12 @@ class CrowdinApi {
    * @param params.language {String} Defines the language issues are associated with.
    * @param params.date_from {String} Issues added from. Use the following ISO 8601 format: YYYY-MM-DD±hh:mm.
    * @param params.date_to {String} Issues added to. Use the following ISO 8601 format: YYYY-MM-DD±hh:mm. */
-  reportedIssues(projectName, params = {}) {
-    return this.postPromise(`project/${projectName}/language-status`, undefined, params);
+  reportedIssues(params = {}) {
+    return this.postPromise(`project/${this.projectName}/language-status`, undefined, params);
   }
 
   /**
    * This method exports single translated files from Crowdin.
-   * @param projectName {String} Should contain the project identifier.
    * @param file {String} This parameter specifies a path to the file that should be exported from the project.
    * @param language {String} Crowdin language code.
    * @param params {Object} See https://support.crowdin.com/api/export-file/
@@ -251,8 +248,8 @@ class CrowdinApi {
    * @param params.format {String} Specify xliff to export file in the XLIFF file format.
    * @param params.export_translated_only {Boolean} Defines whether only translated strings will be exported to the final file.
    * @param params.export_approved_only {Boolean} If set to 1 only approved translations will be exported in resulted file. */
-  exportFile(projectName, file, language, params = {}) {
-    return this.getStream(`project/${projectName}/export-file`, {
+  exportFile(file, language, params = {}) {
+    return this.getStream(`project/${this.projectName}/export-file`, {
       ...params,
       file,
       language
@@ -262,15 +259,15 @@ class CrowdinApi {
   /**
    * Download ZIP file with translations. You can choose the language of translation you need.
    */
-  downloadTranslations(projectName, languageCode) {
-    return this.getStream(`project/${projectName}/download/${languageCode}.zip`);
+  downloadTranslations(languageCode) {
+    return this.getStream(`project/${this.projectName}/download/${languageCode}.zip`);
   }
 
   /**
    * Download ZIP file with all translations.
    */
-  downloadAllTranslations(projectName) {
-    return this.getStream(`project/${projectName}/download/all.zip`);
+  downloadAllTranslations() {
+    return this.getStream(`project/${this.projectName}/download/all.zip`);
   }
 
   /**
@@ -278,24 +275,22 @@ class CrowdinApi {
    * restriction for organization plans). Also API call will be ignored if there were no changes in the project since previous export.
    * You can see whether ZIP archive with latest translations was actually build by status attribute ('built' or 'skipped') returned in response.
    */
-  exportTranslations(projectName) {
-    return this.getPromise(`project/${projectName}/export`);
+  exportTranslations() {
+    return this.getPromise(`project/${this.projectName}/export`);
   }
 
   /**
    * Get the status of translations export.
-   * @param projectName {String} Project identifier.
    * @param branch {String} The name of related version branch (Versions Management).
    */
-  translationExportStatus(projectName, branch = '') {
-    return this.getPromise(`project/${projectName}/export-status`, {
+  translationExportStatus(branch = '') {
+    return this.getPromise(`project/${this.projectName}/export-status`, {
       branch
     });
   }
 
   /**
    * Pre-translate Crowdin project files.
-   * @param projectName {String} Project identifier.
    * @param languages {Array} Set of languages to which pre-translation should be applied.
    * @param files {Array} Files array that should be translated. Values should match your Crowdin project structure.
    * @param params {Object} https://support.crowdin.com/api/pre-translate/
@@ -307,8 +302,8 @@ class CrowdinApi {
    * @param params.apply_untranslated_strings_only {Boolean} Applies translations for untranslated strings only.
    * @param params.perfect_match {Boolean} Pre-translate will be applied only for those strings, that have absolute match in source text and contextual information.
    */
-  preTranslate(projectName, languages, files, params = {}) {
-    return this.postPromise(`project/${projectName}/pre-translate`, undefined, {
+  preTranslate(languages, files, params = {}) {
+    return this.postPromise(`project/${this.projectName}/pre-translate`, undefined, {
       ...params,
       languages,
       files
@@ -317,52 +312,47 @@ class CrowdinApi {
 
   /**
    * Edit Crowdin project
-   * @param projectName {String} Name of the project to change
    * @param params {Object} New parameters for the project.
    */
-  editProject(projectName, params) {
-    return this.postPromise(`project/${projectName}/edit-project`, undefined, params);
+  editProject(params) {
+    return this.postPromise(`project/${this.projectName}/edit-project`, undefined, params);
   }
 
   /**
    * Delete Crowdin project with all translations.
-   * @param projectName {String} Name of the project to delete.
    */
-  deleteProject(projectName) {
-    return this.postPromise(`project/${projectName}/delete-project`);
+  deleteProject() {
+    return this.postPromise(`project/${this.projectName}/delete-project`);
   }
 
   /**
    * Add directory to Crowdin project.
-   * @param projectName {String} Should contain the project identifier.
    * @param directory {String} Directory name (with path if nested directory should be created).
    * @param params {Object} New parameters for the directory.
    */
-  createDirectory(projectName, directory, params) {
-    return this.postPromise(`project/${projectName}/add-directory`, params, {
+  createDirectory(directory, params) {
+    return this.postPromise(`project/${this.projectName}/add-directory`, params, {
       name: directory
     });
   }
 
   /**
    * Rename directory or modify its attributes. When renaming directory the path can not be changed (it means new_name parameter can not contain path, name only).
-   * @param projectName {String} Full directory path that should be modified (e.g. /MainPage/AboutUs).
    * @param directory {String} New directory name.
    * @param params {Object} New parameters for the directory.
    */
-  changeDirectory(projectName, directory, params) {
-    return this.postPromise(`project/${projectName}/change-directory`, params, {
+  changeDirectory(directory, params) {
+    return this.postPromise(`project/${this.projectName}/change-directory`, params, {
       name: directory
     });
   }
 
   /**
    * Delete Crowdin project directory. All nested files and directories will be deleted too.
-   * @param projectName {String} Should contain the project identifier.
    * @param directory {String} Directory path (or just name if the directory is in root).
    */
-  deleteDirectory(projectName, directory) {
-    return this.postPromise(`project/${projectName}/delete-directory`, undefined, {
+  deleteDirectory(directory) {
+    return this.postPromise(`project/${this.projectName}/delete-directory`, undefined, {
       name: directory
     });
   }
@@ -370,21 +360,20 @@ class CrowdinApi {
   /**
    * Download Crowdin project glossaries as TBX file.
    */
-  downloadGlossary(projectName) {
-    return this.getStream(`project/${projectName}/download-glossary`);
+  downloadGlossary() {
+    return this.getStream(`project/${this.projectName}/download-glossary`);
   }
 
   /**
    * Upload your glossaries for Crowdin Project in TBX file format.
-   * @param projectName {String} Should contain the project identifier.
    * @param fileNameOrStream {String|ReadStream} Name of the file to upload or stream which contains file to upload.
    */
-  uploadGlossary(projectName, fileNameOrStream) {
+  uploadGlossary(fileNameOrStream) {
     if (typeof fileNameOrStream === 'string') {
       fileNameOrStream = fs.createReadStream(fileNameOrStream);
     }
 
-    return this.postPromise(`project/${projectName}/upload-glossary`, undefined, {
+    return this.postPromise(`project/${this.projectName}/upload-glossary`, undefined, {
       file: fileNameOrStream
     });
   }
@@ -392,21 +381,20 @@ class CrowdinApi {
   /**
    * Download Crowdin project Translation Memory as TMX file.
    */
-  downloadTranslationMemory(projectName) {
-    return this.postPromise(`project/${projectName}/download-tm`);
+  downloadTranslationMemory() {
+    return this.postPromise(`project/${this.projectName}/download-tm`);
   }
 
   /**
    * Upload your Translation Memory for Crowdin Project in TMX file format.
-   * @param projectName {String} Should contain the project identifier.
    * @param fileNameOrStream {String|ReadStream} Name of the file to upload or stream which contains file to upload.
    */
-  uploadTranslationMemory(projectName, fileNameOrStream) {
+  uploadTranslationMemory(fileNameOrStream) {
     if (typeof fileNameOrStream === 'string') {
       fileNameOrStream = fs.createReadStream(fileNameOrStream);
     }
 
-    return this.postPromise(`project/${projectName}/upload-tm`, undefined, {
+    return this.postPromise(`project/${this.projectName}/upload-tm`, undefined, {
       file: fileNameOrStream
     });
   }
@@ -420,29 +408,26 @@ class CrowdinApi {
 
   /**
    * Generate pseudo translation files for the whole project.
-   * @param projectName {String} Project identifier.
    * @param params {Object} https://support.crowdin.com/api/pseudo-export/
    * @param params.prefix {String} Add special characters at the beginning of each string to show where messages have been concatenated together.
    * @param params.suffix {String} Add special characters at the end of each string to show where messages have been concatenated together.
    * @param params.length_transformation {Number} Make string larger or shorter.
    * @param params.char_transformation {String} Transforms characters to other languages.
    */
-  pseudoExport(projectName, params = {}) {
-    return this.getPromise(`project/${projectName}/pseudo-export`, params);
+  pseudoExport(params = {}) {
+    return this.getPromise(`project/${this.projectName}/pseudo-export`, params);
   }
 
   /**
    * Download ZIP file with pseudo translations.
-   * @param projectName {String} Project identifier.
    */
-  pseudoDownload(projectName) {
-    return this.getStream(`project/${projectName}/pseudo-download`);
+  pseudoDownload() {
+    return this.getStream(`project/${this.projectName}/pseudo-download`);
   }
 
   /**
    * Generate Costs Estimation report to have an insight on how to plan the budget.
    * This report allows you to calculate the approximate translation cost of currently untranslated strings in the project.
-   * @param projectName {String} Project identifier.
    * @param language {String} The language for which the report should be generated.
    * @param params {Object} https://support.crowdin.com/api/export-costs-estimation-report/
    * @param params.unit {String} Defines the report unit.
@@ -455,17 +440,18 @@ class CrowdinApi {
    * @param params.currency {String} Defines the currency for which the whole report is generated.
    * @param params.format {String} Defines the export file format.
    */
-  exportCostsEstimationReport(projectName, language, params = {}) {
-    return this.postPromise(`project/${projectName}/reports/costs-estimation/export`, undefined, params);
+  exportCostsEstimationReport(language, params = {}) {
+    return this.postPromise(`project/${this.projectName}/reports/costs-estimation/export`, undefined, {
+      ...params, language
+    });
   }
 
   /**
    * Download previously generated Costs Estimation report.
-   * @param projectName {String} Project identifier.
    * @param hash {String} Defines hash previously received from the export of Costs Estimation report method.
    */
-  downloadCostsEstimationReport(projectName, hash) {
-    return this.getStream(`project/${projectName}/reports/costs-estimation/download`, {
+  downloadCostsEstimationReport(hash) {
+    return this.getStream(`project/${this.projectName}/reports/costs-estimation/download`, {
       hash
     });
   }
@@ -473,7 +459,6 @@ class CrowdinApi {
   /**
    * Generate Translation Costs report to calculate the real translation cost and know how much your translators
    * and proofreaders should be paid.
-   * @param projectName {String} Project identifier.
    * @param params {Object} https://support.crowdin.com/api/export-translation-costs-report/
    * @param params.unit {String} Defines the report unit.
    * @param params.mode {String} Defines the report mode.
@@ -486,17 +471,16 @@ class CrowdinApi {
    * @param params.role_based_costs {Boolean} Defines whether the costs should be calculated based on contributions or on the role in the project.
    * @param params.group_by {String} Group data by 'user' (default) or by 'language'.
    */
-  exportTranslationCostsReport(projectName, params = {}) {
-    return this.postPromise(`project/${projectName}/reports/translation-costs/export`, undefined, params);
+  exportTranslationCostsReport(params = {}) {
+    return this.postPromise(`project/${this.projectName}/reports/translation-costs/export`, undefined, params);
   }
 
   /**
    * Download previously generated Translation Costs report.
-   * @param projectName {String} Project identifier.
    * @param hash {String} Defines hash previously received from the export of Translation Costs report method.
    */
-  downloadTranslationCostsReport(projectName, hash) {
-    return this.getStream(`project/${projectName}/reports/translation-costs/download`, {
+  downloadTranslationCostsReport(hash) {
+    return this.getStream(`project/${this.projectName}/reports/translation-costs/download`, {
       hash
     });
   }
@@ -504,7 +488,6 @@ class CrowdinApi {
   /**
    * Generate Top Members report to know who contributed the most to
    * your project's translation during the specified date range.
-   * @param projectName {String} Project identifier.
    * @param params {Object} https://support.crowdin.com/api/export-top-members-report/
    * @param params.unit {String} Defines the report unit.
    * @param params.language {String} The language for which the report should be generated.
@@ -512,17 +495,16 @@ class CrowdinApi {
    * @param params.date_to {String} Strings added to.
    * @param params.format {String} Defines the export file format.
    */
-  exportTopMembersReport(projectName, params = {}) {
-    return this.postPromise(`project/${projectName}/reports/top-members/export`, undefined, params);
+  exportTopMembersReport(params = {}) {
+    return this.postPromise(`project/${this.projectName}/reports/top-members/export`, undefined, params);
   }
 
   /**
    * Download previously generated Top Members report.
-   * @param projectName {String} Project identifier.
    * @param hash {String} Defines hash previously received from the export of Top Members report method.
    */
-  downloadTopMembersReport(projectName, hash) {
-    return this.getStream(`project/${projectName}/reports/top-members/download`, {
+  downloadTopMembersReport(hash) {
+    return this.getStream(`project/${this.projectName}/reports/top-members/download`, {
       hash
     });
   }

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,10 @@ API client for the [Crowdin API](https://support.crowdin.com/api/api-integration
 ## Usage
 ```
 var CrowdinApi = require('crowdin-api');
-var api = new CrowdinApi({ apiKey: 'abcd' }); // Get this from your project page
+var api = new CrowdinApi({
+  apiKey: 'abcd', // Get this from your project page
+  project: 'project-name'
+});
 
-api.uploadFile('project-name', ...).then(function(result) {...}).catch(function(err) {...});
+api.updateFile(files, ...).then(function(result) {...}).catch(function(err) {...});
 ```


### PR DESCRIPTION
This is a proposal to change the API to pass project identifier once during class initialization. 