### PR TITLE
Pass name as `projectName` as required

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ API client for the [Crowdin API](https://support.crowdin.com/api/api-integration
 var CrowdinApi = require('crowdin-api');
 var api = new CrowdinApi({
   apiKey: 'abcd', // Get this from your project page
-  project: 'project-name'
+  projectName: 'project-name'
 });
 
 api.updateFile(files, ...).then(function(result) {...}).catch(function(err) {...});


### PR DESCRIPTION
The JS API uses the key `projectName` not `project`. Ensure the docs are
up-to-date.